### PR TITLE
fix pointer indicator bug

### DIFF
--- a/src/app/segments/AboutSection.tsx
+++ b/src/app/segments/AboutSection.tsx
@@ -35,7 +35,7 @@ const AboutSection = ({...props}) => {
                                     <Text $fontSize={["1.1rem", "1.25rem", "1.25rem"]} $fontWeight={300}
                                           $maxWidth="48ch">
                                         I do this by working as a designer, as an engineer, as whatever is necessary,
-                                        to infuse my <InlineLink onClick={scrollToProjectsSection}>projects</InlineLink>
+                                        to infuse my<InlineLink onClick={scrollToProjectsSection}>projects</InlineLink>
                                         with compassion and purpose.
                                     </Text>
                                 </FlexColumn>

--- a/src/components/Blob/index.tsx
+++ b/src/components/Blob/index.tsx
@@ -31,13 +31,7 @@ const Blob = ({size}: BlobProps) => {
         ref.current.style.top = `${e.clientY - size / 2}px`
         ref.current.style.left = `${e.clientX - size / 2}px`
 
-        if (shouldExpandOnHover(e.target)) {
-            ref.current.style.transform = `scale(1)`
-            ref.current.style.borderWidth = `2rem`
-        } else {
-            ref.current.style.transform = `scale(0.5)`
-            ref.current.style.borderWidth = `0rem`
-        }
+        ref.current.style.transform = shouldExpandOnHover(e.target) ? `scale(1)` : `scale(0.5)`
     }, [ref, size])
 
     useEffect(() => {
@@ -56,16 +50,16 @@ const BlobWrapper = styled.div<BlobProps>`
   transition: transform ${smoothTransitionStyles}, backdrop-filter ${smoothTransitionStyles}, border ${smoothTransitionStyles}, background-color ${smoothTransitionStyles}, top 180ms ease-out, left 180ms ease-out;
   z-index: 2;
   position: fixed;
-  background-color: rgb(0 0 0 / 0);
+  background-color: rgb(var(--base-color-not-white) / 0.5);
   pointer-events: none;
   border-radius: ${(props: BlobProps) => `${props.size}px`};
   height: ${(props: BlobProps) => `${props.size}px`};
   width: ${(props: BlobProps) => `${props.size}px`};
   transform: scale(0.5);
   backdrop-filter: invert(100%);
-  border: 0 solid rgb(var(--base-color-not-white) / 0.5);
-  
-  ${mobileOnly} {
+  -webkit-backdrop-filter: invert(100%);
+
+  @media (hover: none) {
     visibility: hidden;
   }
 `

--- a/src/components/Blob/index.tsx
+++ b/src/components/Blob/index.tsx
@@ -31,7 +31,9 @@ const Blob = ({size}: BlobProps) => {
         ref.current.style.top = `${e.clientY - size / 2}px`
         ref.current.style.left = `${e.clientX - size / 2}px`
 
-        ref.current.style.transform = shouldExpandOnHover(e.target) ? `scale(1)` : `scale(0.5)`
+        const shouldExpand = shouldExpandOnHover(e.target)
+        ref.current.style.transform = shouldExpand ? `scale(1)` : `scale(0.5)`
+        ref.current.style.backgroundColor = shouldExpand ? `rgb(var(--base-color-not-white) / 0.5)` : `rgb(0 0 0 / 0)`
     }, [ref, size])
 
     useEffect(() => {
@@ -50,7 +52,7 @@ const BlobWrapper = styled.div<BlobProps>`
   transition: transform ${smoothTransitionStyles}, backdrop-filter ${smoothTransitionStyles}, border ${smoothTransitionStyles}, background-color ${smoothTransitionStyles}, top 180ms ease-out, left 180ms ease-out;
   z-index: 2;
   position: fixed;
-  background-color: rgb(var(--base-color-not-white) / 0.5);
+  background-color: rgb(0 0 0 / 0);
   pointer-events: none;
   border-radius: ${(props: BlobProps) => `${props.size}px`};
   height: ${(props: BlobProps) => `${props.size}px`};


### PR DESCRIPTION
Bug was that on touch devices with Safari (guessing, website was opened on an apple device from discord, I'm assuming it defaults to using Safari on iOS devices), tapping the smile block would still cause a faint circle to pop up, 2 problems:

- The circle was not inverting the colors behind it (fixed with a `-webkit-`)
- The circle shouldn't show up on touch devices at all

![image](https://github.com/Opeyem1a/portfolio-v2/assets/60050089/ddb3a03b-3bd8-4508-9eb5-c0ccb6dcf27a)
![image](https://github.com/Opeyem1a/portfolio-v2/assets/60050089/10cae875-4eac-41e3-8adb-f9aa34893bd1)
